### PR TITLE
Fix typo in Feed page function call

### DIFF
--- a/Brenzgram/Feed.html
+++ b/Brenzgram/Feed.html
@@ -36,7 +36,7 @@
                     <a class="nav-link" href="/Users/make/Desktop/Brenzgram/Index.html">Home <span class="sr-only">(current)</span></a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" onclick="toogleWideView(x)">Breit auflisten</a>
+                    <a class="nav-link" onclick="toggleWideView('wide')">Breit auflisten</a>
                 </li>
             </ul>
             <form class="form-inline my-2 my-lg-0">


### PR DESCRIPTION
## Summary
- correct typo in onclick call in Feed.html

## Testing
- `grep -n "toggleWideView" -n Brenzgram/Feed.html | head`

------
https://chatgpt.com/codex/tasks/task_e_6849297ca2908325bada34dfe0283521